### PR TITLE
Fix type mismatch for invitation_code_id

### DIFF
--- a/person.go
+++ b/person.go
@@ -42,10 +42,10 @@ type Person struct {
 		Saturday  bool `json:"saturday"`
 		Sunday    bool `json:"sunday"`
 	} `json:"working_days"`
-	ColorBlind bool     `json:"color_blind"`
-	Roles      []string `json:"roles"`
-	InvitationCodeID    string `json:"invitation_code_id"`
-	PersonalFeedTokenID int    `json:"personal_feed_token_id"`
+	ColorBlind          bool     `json:"color_blind"`
+	Roles               []string `json:"roles"`
+	InvitationCodeID    int      `json:"invitation_code_id"`
+	PersonalFeedTokenID int      `json:"personal_feed_token_id"`
 }
 
 // People returns all people being scheduled in Forecast


### PR DESCRIPTION
Updates type of InvitationCodeId from `string` to `int` as highlighted in issue #23.

Tests pass:

```Suite: Role
Total: 2 | Focused: 0 | Pending: 0
..
Passed: 2 | Failed: 0 | Skipped: 0

Suite: forecast
Total: 27 | Focused: 0 | Pending: 0
...........................
Passed: 27 | Failed: 0 | Skipped: 0

PASS
ok      github.com/joefitzgerald/forecast       0.758s
```